### PR TITLE
Correct typo in msm.conf to fix rsync backups

### DIFF
--- a/msm.conf
+++ b/msm.conf
@@ -93,7 +93,7 @@ WORLD_RDIFF_PATH="/opt/msm/rdiff-backup/worlds"
 # If you want to use rsync for backups you need to have it installed on your server.
 
 # Are rsync backups enabled ?
-RSYNC_BACKUP_ENALBED="false"
+RSYNC_BACKUP_ENABLED="false"
 
 # Where "rsync" world backups are stored.
 WORLD_RSYNC_PATH="/opt/msm/rsync/worlds"


### PR DESCRIPTION
RSYNC_BACKUP_ENALBED was misspelled, which was preventing rsync backups
from working.